### PR TITLE
Hittable Control v1

### DIFF
--- a/vscripts/confogl.nut
+++ b/vscripts/confogl.nut
@@ -259,6 +259,7 @@ function LoadPlugin(name) {
 
 
 LoadPlugin("confogl_no_spitter");
+LoadPlugin("confogl_hittable_control");
 
 // Msg(format("ModeScript = this? %s\n", g_ModeScript == this ? "true" : "false"));
 // Msg(format("ChallengeScript = this? %s\n", ::DirectorScript.MapScript.ChallengeScript == this ? "true" : "false"));

--- a/vscripts/confogl_hittable_control.nut
+++ b/vscripts/confogl_hittable_control.nut
@@ -1,0 +1,74 @@
+local isGauntletFinale = false;
+local allowDamageTimestampTable = {};
+local hittableDamage = 100;
+local hittableImmunityTime = 1.2;
+
+ // finale_start doesn't fire for Gauntlet finales, but this does. We can't use OnGameplayStart(),
+ // because the trigger_finale does not exist until after the initial radio conversation.
+function OnGameEvent_finale_radio_start(params)
+{
+    if (NetProps.GetPropInt(Entities.FindByClassname(null, "trigger_finale"), "m_type") == 1)
+    {
+        isGauntletFinale = true;
+    }
+}
+
+function AllowTakeDamage(damageTable)
+{
+    if (!damageTable.Attacker.IsValid() || !damageTable.Inflictor.IsValid() || !damageTable.Victim.IsValid())
+	{
+		return true;
+	}
+    else if (!damageTable.Attacker.IsPlayer() || !damageTable.Victim.IsPlayer())
+    {
+        return true;
+    }
+
+    if (damageTable.Inflictor != null)
+    {
+        local inflictorClassname = damageTable.Inflictor.GetClassname();
+        if (inflictorClassname == "prop_physics" || inflictorClassname == "prop_car_alarm")
+        {
+            if (damageTable.Attacker.GetZombieType() == 8) // Attacker is a Tank.
+            {
+                if (damageTable.Attacker == damageTable.Victim)
+                {
+                    return false; // Prevent Tank self-harm.
+                }
+                else if (damageTable.Victim.IsSurvivor())
+                {
+                    if (isGauntletFinale)
+                    {
+                        damageTable.DamageDone = hittableDamage * 4; // Hittable damage on Gauntlet finales is divided by 4 past where this function returns.
+                    }
+                    else
+                    {
+                        damageTable.DamageDone = hittableDamage;
+                    }
+                    if (damageTable.Victim in allowDamageTimestampTable)
+                    {
+                        if ((allowDamageTimestampTable[damageTable.Victim] - Time()) > 0.0)
+                        {
+                            return false; // Not enough time has passed, prevent this damage.
+                        }
+                        else
+                        {
+                            allowDamageTimestampTable[damageTable.Victim] <- (Time() + hittableImmunityTime)
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        allowDamageTimestampTable[damageTable.Victim] <- (Time() + hittableImmunityTime)
+
+                        return true; // Allow this damage and prevent damage for hittableImmunityTime seconds.
+                    }
+                }
+            }
+        }
+    }
+
+    return true; // Let the damage through if we make it this far.
+}
+
+Msg("Hittable Control: LOADED!\n");

--- a/vscripts/confogl_hittable_control.nut
+++ b/vscripts/confogl_hittable_control.nut
@@ -1,0 +1,74 @@
+local isGauntletFinale = false;
+local allowDamageTimestampTable = {};
+local hittableDamage = 100;
+local hittableImmunityTime = 1.2;
+
+ // finale_start doesn't fire for Gauntlet finales, but this does. We can't use OnGameplayStart(),
+ // because the trigger_finale does not exist until after the initial radio conversation.
+function OnGameEvent_finale_radio_start(params)
+{
+    if (NetProps.GetPropInt(Entities.FindByClassname(null, "trigger_finale"), "m_type") == 1)
+    {
+        isGauntletFinale = true;
+    }
+}
+
+function AllowTakeDamage(damageTable)
+{
+    if (!damageTable.Attacker.IsValid() || !damageTable.Inflictor.IsValid() || !damageTable.Victim.IsValid())
+    {
+        return true;
+    }
+    else if (!damageTable.Attacker.IsPlayer() || !damageTable.Victim.IsPlayer())
+    {
+        return true;
+    }
+
+    if (damageTable.Inflictor != null)
+    {
+        local inflictorClassname = damageTable.Inflictor.GetClassname();
+        if (inflictorClassname == "prop_physics" || inflictorClassname == "prop_car_alarm")
+        {
+            if (damageTable.Attacker.GetZombieType() == 8) // Attacker is a Tank.
+            {
+                if (damageTable.Attacker == damageTable.Victim)
+                {
+                    return false; // Prevent Tank self-harm.
+                }
+                else if (damageTable.Victim.IsSurvivor())
+                {
+                    if (isGauntletFinale)
+                    {
+                        damageTable.DamageDone = hittableDamage * 4; // Hittable damage on Gauntlet finales is divided by 4 past where this function returns.
+                    }
+                    else
+                    {
+                        damageTable.DamageDone = hittableDamage;
+                    }
+                    if (damageTable.Victim in allowDamageTimestampTable)
+                    {
+                        if ((allowDamageTimestampTable[damageTable.Victim] - Time()) > 0.0)
+                        {
+                            return false; // Not enough time has passed, prevent this damage.
+                        }
+                        else
+                        {
+                            allowDamageTimestampTable[damageTable.Victim] <- (Time() + hittableImmunityTime)
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        allowDamageTimestampTable[damageTable.Victim] <- (Time() + hittableImmunityTime)
+
+                        return true; // Allow this damage and prevent damage for hittableImmunityTime seconds.
+                    }
+                }
+            }
+        }
+    }
+
+    return true; // Let the damage through if we make it this far.
+}
+
+Msg("Hittable Control: LOADED!\n");

--- a/vscripts/confogl_hittable_control.nut
+++ b/vscripts/confogl_hittable_control.nut
@@ -16,9 +16,9 @@ function OnGameEvent_finale_radio_start(params)
 function AllowTakeDamage(damageTable)
 {
     if (!damageTable.Attacker.IsValid() || !damageTable.Inflictor.IsValid() || !damageTable.Victim.IsValid())
-	{
-		return true;
-	}
+    {
+        return true;
+    }
     else if (!damageTable.Attacker.IsPlayer() || !damageTable.Victim.IsPlayer())
     {
         return true;


### PR DESCRIPTION
Kept this nice and simple for now. All hittables always do 1 instance of 100 damage, at a maximum rate of once per 1.2 seconds, no matter the circumstance. Gauntlet finales are handled as a special case because they divide the damage by 4 after the AllowTakeDamage() function call.